### PR TITLE
upgrade-jekyll

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ PLATFORMS
 
 DEPENDENCIES
   http_parser.rb (~> 0.6.0)
-  jekyll (~> 4.3.3)
+  jekyll (~> 4)
   jekyll-email-protect
   jekyll-environment-variables
   jekyll-feed (~> 0.12)


### PR DESCRIPTION
```console
/opt/hostedtoolcache/Ruby/3.2.2/x64/bin/bundle install --jobs 4
The dependencies in your gemfile changed, but the lockfile can't be updated
because frozen mode is set
You have added to the Gemfile:
* jekyll (~> 4)
You have deleted from the Gemfile:
* jekyll (~> 4.3.3)
Run `bundle install` elsewhere and add the updated Gemfile to version control.
If this is a development machine, remove the Gemfile.lock freeze by running
`bundle config set frozen false`.
Error: The process '/opt/hostedtoolcache/Ruby/3.2.2/x64/bin/bundle' failed with exit code 16
##[debug]Node Action run completed with exit code 1
```